### PR TITLE
feat: add verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Then run:
 bruty https://fake.web -f uris.txt
 ```
 
+If you don't want to wait until the command ends to see the results use the `-v`
+flag.
+
 ### Fake 404 pages
 
 Some sites return a 200 status code for the 404, if it's your case, inspect the
@@ -50,6 +53,16 @@ Once you know it works, run it against all the uris:
 
 ```bash
 bruty https://fake.web -f uris.txt -n '404 error'
+```
+
+### Untrusted return codes
+
+Some websites use the 200 status code when they should use 404 or even 30X. Use
+the `-i` flag to ignore the checking of the status code. It should be used with
+the `-n` flag to tell the right urls from the wrong.
+
+```bash
+bruty https://fake.web -f uris.txt -i -n '404 error'
 ```
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ exclude = '''
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-vv --tb=short -n auto"
+addopts = "-vv --tb=short"
 python_paths = "."
 norecursedirs = [
     ".tox",

--- a/src/bruty/__init__.py
+++ b/src/bruty/__init__.py
@@ -2,4 +2,6 @@
 
 from typing import List
 
-__all__: List[str] = []
+from .services import bruteforce
+
+__all__: List[str] = ["bruteforce"]

--- a/src/bruty/adapters/__init__.py
+++ b/src/bruty/adapters/__init__.py
@@ -1,5 +1,0 @@
-"""Module to store the functions shared by the different adapters."""
-
-import logging
-
-log = logging.getLogger(__name__)

--- a/src/bruty/entrypoints/__init__.py
+++ b/src/bruty/entrypoints/__init__.py
@@ -5,9 +5,8 @@ Functions:
 """
 
 import logging
-import sys
 
-log = logging.getLogger(__name__)
+from rich.logging import RichHandler
 
 
 # I have no idea how to test this function :(. If you do, please send a PR.
@@ -17,15 +16,21 @@ def load_logger(verbose: bool = False) -> None:  # pragma no cover
     Args:
         verbose: Set the logging level to Debug.
     """
+    logging.getLogger("selenium").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.addLevelName(logging.INFO, "[\033[36m+\033[0m]")
     logging.addLevelName(logging.ERROR, "[\033[31m+\033[0m]")
     logging.addLevelName(logging.DEBUG, "[\033[32m+\033[0m]")
     logging.addLevelName(logging.WARNING, "[\033[33m+\033[0m]")
     if verbose:
         logging.basicConfig(
-            stream=sys.stderr, level=logging.DEBUG, format="  %(levelname)s %(message)s"
+            level=logging.DEBUG,
+            format="%(message)s",
+            handlers=[RichHandler(rich_tracebacks=True)],
         )
     else:
         logging.basicConfig(
-            stream=sys.stderr, level=logging.INFO, format="  %(levelname)s %(message)s"
+            level=logging.INFO,
+            format="%(message)s",
+            handlers=[RichHandler(rich_tracebacks=True)],
         )

--- a/src/bruty/entrypoints/cli.py
+++ b/src/bruty/entrypoints/cli.py
@@ -16,16 +16,20 @@ from . import load_logger
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("-n", "--not_found_regexp")
 @click.option("-u", "--uris", multiple=True)
+@click.option("-i", "--ignore_status_code", is_flag=True)
 def cli(
     url: str,
-    verbose: bool = False,
+    verbose: bool,
+    ignore_status_code: bool,
     uris_file_path: Optional[str] = None,
     uris: Optional[List[str]] = None,
     not_found_regexp: Optional[str] = None,
 ) -> None:
     """Command line interface main click entrypoint."""
     load_logger(verbose)
-    urls = bruteforce(url, uris, uris_file_path, not_found_regexp)
+    urls = bruteforce(
+        url, uris, uris_file_path, not_found_regexp, verbose, ignore_status_code
+    )
     for url in urls:
         print(url)
 

--- a/tests/api_server.py
+++ b/tests/api_server.py
@@ -3,6 +3,7 @@
 from typing import Dict
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
 
 app = FastAPI()
 
@@ -23,3 +24,21 @@ async def inexistent() -> None:
 async def wrong_404_page() -> Dict[str, str]:
     """Return a 200 status code even if it's not found."""
     return {"msg": "404 error"}
+
+
+@app.get("/302_to_200")
+async def rediretion_to_200() -> RedirectResponse:
+    """Return a redirection to a 200 page."""
+    return RedirectResponse("/existent")
+
+
+@app.get("/302_to_404")
+async def rediretion_to_404() -> RedirectResponse:
+    """Return a redirection to a 404 page."""
+    return RedirectResponse("/inexistent")
+
+
+@app.get("/status_code_999")
+async def status_code_999() -> None:
+    """Return a status code of 999."""
+    raise HTTPException(status_code=999, detail="Really broken website")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def run_server() -> None:
     uvicorn.run(app)
 
 
-@pytest.fixture()
+@pytest.fixture(name="_server", scope="session")
 def _server() -> Generator[None, None, None]:
     """Start the fake api server."""
     proc = Process(target=run_server, args=(), daemon=True)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,1 +1,73 @@
 """Tests the service layer."""
+
+import logging
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+
+from bruty import bruteforce
+
+
+@pytest.mark.usefixtures("_server")
+def test_bruty_follows_redirections() -> None:
+    """
+    Given: A uri that redirects to `/existent` which is a 200
+    When: The bruteforce service is called
+    Then: The 200 endpoint is registered
+    """
+    result = bruteforce("http://localhost:8000", ["302_to_200"])
+
+    assert result == ["http://localhost:8000/existent"]
+
+
+@pytest.mark.usefixtures("_server")
+def test_bruty_follows_redirections_to_404() -> None:
+    """
+    Given: A uri that redirects to `/inexistent` which is a 404
+    When: The bruteforce service is called
+    Then: The 404 endpoint is not registered
+    """
+    result = bruteforce("http://localhost:8000", ["302_to_404"])
+
+    assert result == []
+
+
+@pytest.mark.usefixtures("_server")
+def test_bruty_registers_redirections_in_the_log(caplog: LogCaptureFixture) -> None:
+    """
+    Given: A uri that redirects to `/existent` which is a 200
+    When: The bruteforce service is called in verbose mode
+    Then: The redirection is registered in the logs
+    """
+    caplog.set_level(logging.DEBUG)
+
+    result = bruteforce("http://localhost:8000", ["302_to_200"], verbose=True)
+
+    assert result == ["http://localhost:8000/existent"]
+    assert (
+        "bruty.services",
+        logging.DEBUG,
+        "Redirect: http://localhost:8000/302_to_200 -> http://localhost:8000/existent",
+    ) in caplog.record_tuples
+
+
+@pytest.mark.usefixtures("_server")
+def test_bruty_doesnt_register_redirections_to_404_in_the_log(
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Given: A uri that redirects to `/inexistent` which is a 404
+    When: The bruteforce service is called in verbose mode
+    Then: The redirection is not registered in the logs
+    """
+    caplog.set_level(logging.DEBUG)
+
+    result = bruteforce("http://localhost:8000", ["302_to_404"], verbose=True)
+
+    assert result == []
+    assert (
+        "bruty.services",
+        logging.DEBUG,
+        "Redirect: http://localhost:8000/302_to_404 -> "
+        "http://localhost:8000/inexistent",
+    ) not in caplog.record_tuples


### PR DESCRIPTION
To show the results of the command in real time instead of waiting for
it to end.

feat: add the ignore_return_codes flag

To process well websites whose status code can't be trusted

tests: improve test robustness

Launch the api server once per session instead of on each test and
remove the parallel execution as it was giving errors.

perf: change the webdriver chrome_options to options

As it's going to be deprecated soon

fix: handle redirections well

Before they wouldn't be catched

<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
